### PR TITLE
Synchronize script and documentation with OSS

### DIFF
--- a/DoxyGen/infrastructure/infrastructure.dxy
+++ b/DoxyGen/infrastructure/infrastructure.dxy
@@ -858,7 +858,7 @@ WARN_LOGFILE           =
 
 INPUT                  = ./src/main.md  \
                          ./src/aws.md  \
-                         ./src/avh_doc.md \
+                         ./src/vht_doc.md \
                          ./src/github.md \
                          ./src/mdk.md
 

--- a/DoxyGen/infrastructure/src/vht_doc.md
+++ b/DoxyGen/infrastructure/src/vht_doc.md
@@ -1,4 +1,4 @@
-# AVH CLI Script
+# VHT CLI Script
 
 This script is a wrapper around AWS CLI to start/connect/stop \ref AWS EC2 instance easily.
 
@@ -11,9 +11,9 @@ This script is a wrapper around AWS CLI to start/connect/stop \ref AWS EC2 insta
 
 This script can be used with one of the argument below:
 
-* `./avh_cli.py start`: to launch an AVH AMI instance. If an instance is already running, the user will be asked to confirm a new instance needs to be launched.
-* `./avh_cli.py status`: to display AVH AMI instance(s) status and get the instance(s) IP address.
-* `./avh_cli.py stop`: to terminate an AVH AMI instance. The user will be asked to confirm the instance ID to terminate. Note that the data stored in the instance will be lost.
+* `./vht_cli.py start`: to launch an Arm Virtual Hardware AMI instance. If an instance is already running, the user will be asked to confirm a new instance needs to be launched.
+* `./vht_cli.py status`: to display an Arm Virtual Hardware AMI instance(s) status and get the instance(s) IP address.
+* `./vht_cli.py stop`: to terminate an Arm Virtual Hardware AMI instance. The user will be asked to confirm the instance ID to terminate. Note that the data stored in the instance will be lost.
 
 The script supports additional options:
 
@@ -29,7 +29,7 @@ Note that the script will create a default Amazon Virtual Private Cloud (VPC) if
 ### Instance start wihout specifying any key
 
 ```
-$ ./avh_cli.py start
+$ ./vht_cli.py start
 [INFO]	No key specified and avh_user key not found, creating 'avh_user' key...
 [INFO]	Key has been saved as /home/<user>/.ssh/avh_user.pem.
 Starting Arm Virtual Hardware AWS EC2 instance...
@@ -38,10 +38,10 @@ Launched Instance ID i-XXXXXXXXXXXXXXXX
 
 ### Connecting to the instance
 
-When an instance has been started, with the avh\_cli.py script, its IP address can be retrieved with:
+When an instance has been started, with the vht\_cli.py script, its IP address can be retrieved with:
 
 ```
-$ ./avh_cli.py status
+$ ./vht_cli.py status
 | Instance ID         | Public IP        | Status     |
 =======================================================
 | i-XXXXXXXXXXXXXXXX  | Y.YYY.YYY.YYY    | RUNNING    |
@@ -51,7 +51,7 @@ $ ./avh_cli.py status
 ### Instance stop
 
 ```
-$ ./avh_cli.py stop
+$ ./vht_cli.py stop
 Running instance ID i-XXXXXXXXXXXXXXXX found (public IP Y.YYY.YYY.YYY)
 The instance will be terminated and all data will be lost. Please enter the instance ID to stop it (leave empty to cancel): i-XXXXXXXXXXXXXXXX
 Stopping ORTA instance ID i-XXXXXXXXXXXXXXXX...

--- a/infrastructure/vht_cli.py
+++ b/infrastructure/vht_cli.py
@@ -26,11 +26,10 @@ import logging
 import platform
 
 
-# Arm Virtual Hardware AMI
-# version 1.0.0
-ImgId="ami-0b53117f38a0cd18b"
+# Arm Virtual Hardware AMI version
+avh_version="1.0.0"
 
-InstType="t3a.medium"
+InstType="c5.large"
 
 # Set verbosity level
 verbosity = logging.INFO
@@ -52,19 +51,41 @@ else:
     nc="\033[0m"
 
 
+def get_avh_imgid(region):
+    global avh_version
+
+    cmd_im = "aws ec2 describe-images --region {} --filters Name=name,Values='ArmVirtualHardware-{}*' Name=owner-alias,Values='aws-marketplace' --output json".format(
+    	    region, avh_version)
+
+    try:
+        out_im = subprocess.check_output(cmd_im, stderr=subprocess.STDOUT, shell=True).decode("utf-8")
+    except subprocess.CalledProcessError as e:
+        logging.error(red + "Could not get Arm Virtual Hardware Instance ID for region {}.".format(region) + nc)
+        sys.exit(1)
+
+    outd_im = json.loads(out_im)
+    for instance in outd_im['Images']:
+        ImgId = instance['ImageId']
+        logging.info("Image ID is {}".format(ImgId))
+
+    return ImgId
+
+
 def start_avh(profile, key, region, initfile):
-    global ImgId, InstType
+    global InstType
 
     print("Starting AVH instance...")
 
-    if status_avh(profile, region, False)[0] > 0 :
+    [n, arr, ImgId] = status_avh(profile, region, False)
+
+    if n > 0 :
         print(orange + "One or more AVH instances are already running." + nc)
         confirm = input("Please confirm to launch a new instance [Y/n]: ")
         if confirm != "Y":
             print("Cancelling... No instance will be started.")
             sys.exit(1)
 
-    cmd = "aws ec2 run-instances --profile {} --image-id {} --instance-type {} --key-name {} --region {}".format(
+    cmd = "aws ec2 run-instances --profile {} --image-id {} --instance-type {} --key-name {} --region {} --output json".format(
             profile, ImgId, InstType, key, region)
 
     if initfile != None :
@@ -75,6 +96,7 @@ def start_avh(profile, key, region, initfile):
     try:
         out = subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=True).decode("utf-8")
     except subprocess.CalledProcessError as e:
+        print(e.output)
         errtype = str(e.output).split(")")[0].split("(")[1]
         if errtype == "VPCIdNotSpecified":
             logging.info(orange + "Running the start command failed: default VPC not found. Creating VPC..." + nc)
@@ -106,7 +128,8 @@ def start_avh(profile, key, region, initfile):
     return
 
 def status_avh(profile, region, printv):
-    global ImgId
+    # Get ImageID from region
+    ImgId = get_avh_imgid(region)
 
     n_instances = 0
     arr_inst = []
@@ -142,11 +165,11 @@ def status_avh(profile, region, printv):
             else :
                 print("| {}\t| {}\t\t| {}\t|".format(i[0], i[1], i[2]))
 
-    return n_instances, arr_inst
+    return n_instances, arr_inst, ImgId
 
 
 def stop_avh(profile, region):
-    [n, arr] = status_avh(profile, region, False)
+    [n, arr, ImgId] = status_avh(profile, region, False)
 
     if n == 0 :
         logging.error(red + "No AVH instance is running." + nc)
@@ -217,12 +240,12 @@ if __name__ == "__main__":
     if args.command.lower() == "start" :
         # Key check
         if args.key == None:
-            args.key = "avh_user"
-            if os.path.isfile(os.path.join(os.path.expanduser('~'),'.ssh/avh_user.pem')) == False :
-                logging.info(orange + "No key specified and avh_user key not found, creating 'avh_user' key..." + nc)
+            args.key = "avh_user_{}".format(args.region)
+            if os.path.isfile(os.path.join(os.path.expanduser('~'),'.ssh/avh_user_{}.pem'.format(args.region))) == False :
+                logging.info(orange + "No key specified and avh_user_{} key not found, creating 'avh_user_{}' key...".format(args.region, args.region) + nc)
 
-                cmd = "aws ec2 create-key-pair --key-name avh_user --profile {} --region {}".format(
-                            args.profile, args.region)
+                cmd = "aws ec2 create-key-pair --key-name avh_user_{} --profile {} --region {} --output json".format(
+                            args.region, args.profile, args.region)
                 try:
                     out = subprocess.check_output(cmd, shell=True).decode("utf-8")
                 except subprocess.CalledProcessError:
@@ -230,7 +253,7 @@ if __name__ == "__main__":
                     sys.exit(1)
 
                 outd = json.loads(out)
-                key_file = open(os.path.join(os.path.expanduser('~'),'.ssh/avh_user.pem'), 'x')
+                key_file = open(os.path.join(os.path.expanduser('~'),'.ssh/avh_user_{}.pem'.format(args.region)), 'x')
                 try:
                     key_file.write(outd["KeyMaterial"])
                 except:
@@ -241,11 +264,12 @@ if __name__ == "__main__":
 
                 # Set permissions
                 if platform.system() == "Linux" :
-                    os.system('chmod 600 ~/.ssh/avh_user.pem')
+                    os.system('chmod 600 ~/.ssh/avh_user_{}.pem'.format(args.region))
 
-                logging.info(orange + "Key has been saved as {}.ssh".format(os.path.expanduser('~') + os.path.sep) + os.path.sep + "avh_user.pem." + nc)
+                logging.info(orange + "Key has been saved as {}.ssh".format(os.path.expanduser('~') + os.path.sep) 
+		    + os.path.sep + "avh_user_{}.pem.".format(args.region) + nc)
             else:
-                logging.info(orange + "Using 'avh_user' key in {}.ssh ...".format(os.path.expanduser('~') + os.path.sep) + nc)
+                logging.info(orange + "Using 'avh_user_{}' key in {}.ssh ...".format(args.region, os.path.expanduser('~') + os.path.sep) + nc)
 
         start_avh(args.profile, args.key, args.region, args.cloudinit)
 


### PR DESCRIPTION
Fix hardcoded AMI ID for us-east-1 region only. Now works for other AWS regions.
Change script name and update documentation accordingly.
Use recommended c5.large instance instead of t3.medium and brings significant performance improvement.