### PR TITLE
Fix iot_socket's missing include

### DIFF
--- a/interface/vsocket/iot_socket.c
+++ b/interface/vsocket/iot_socket.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include "iot_socket.h"
+#include "arm_vsocket.h"
 #ifdef   _RTE_
 #include "RTE_Components.h"
 #endif


### PR DESCRIPTION
arm_vsocket.h is required by iot_socket.c because this implementation use some types (like vSocketCreateIO_t) are defined in this header.