### PR TITLE
Made Python logging to use getLogger(__name__)

### DIFF
--- a/interface/audio/python/arm_vsi0.py
+++ b/interface/audio/python/arm_vsi0.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Arm Limited. All rights reserved.
+# Copyright (c) 2021-2024 Arm Limited. All rights reserved.
 
 # Virtual Streaming Interface instance 0 Python script: Audio Input
 
@@ -13,15 +13,18 @@
 import logging
 import wave
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI0: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -65,26 +68,26 @@ Data = bytearray()
 #  @param name name of WAVE file to open
 def openWAVE(name):
     global WAVE
-    logging.info("Open WAVE file (read mode): {}".format(name))
+    logger.info("Open WAVE file (read mode): {}".format(name))
     WAVE = wave.open(name, 'rb')
-    logging.info("  Number of channels: {}".format(WAVE.getnchannels()))
-    logging.info("  Sample bits: {}".format(WAVE.getsampwidth() * 8))
-    logging.info("  Sample rate: {}".format(WAVE.getframerate()))
-    logging.info("  Number of frames: {}".format(WAVE.getnframes()))
+    logger.info("  Number of channels: {}".format(WAVE.getnchannels()))
+    logger.info("  Sample bits: {}".format(WAVE.getsampwidth() * 8))
+    logger.info("  Sample rate: {}".format(WAVE.getframerate()))
+    logger.info("  Number of frames: {}".format(WAVE.getnframes()))
 
 ## Read WAVE frames (global WAVE object) into global AudioFrames object
 #  @param n number of frames to read
 #  @return frames frames read
 def readWAVE(n):
     global WAVE
-    logging.info("Read WAVE frames")
+    logger.info("Read WAVE frames")
     frames = WAVE.readframes(n)
     return frames
 
 ## Close WAVE file (global WAVE object)
 def closeWAVE():
     global WAVE
-    logging.info("Close WAVE file")
+    logger.info("Close WAVE file")
     WAVE.close()
 
 
@@ -92,7 +95,7 @@ def closeWAVE():
 #  @param block_size size of block to load (in bytes)
 def loadAudioFrames(block_size):
     global Data
-    logging.info("Load audio frames into data buffer")
+    logger.info("Load audio frames into data buffer")
     frame_size = CHANNELS * ((SAMPLE_BITS + 7) // 8)
     frames_max = block_size // frame_size
     Data = readWAVE(frames_max)
@@ -100,17 +103,17 @@ def loadAudioFrames(block_size):
 
 ## Initialize
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -120,10 +123,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -134,21 +137,21 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
 
 ## Timer event (called at Timer Overflow)
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -157,11 +160,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -171,14 +174,14 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     loadAudioFrames(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -188,10 +191,10 @@ def rdDataDMA(size):
 #  @param size size of data to write (in bytes, multiple of 4)
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -202,10 +205,10 @@ def wrCONTROL(value):
     global CONTROL
     if ((value ^ CONTROL) & CONTROL_ENABLE_Msk) != 0:
         if (value & CONTROL_ENABLE_Msk) != 0:
-            logging.info("Enable Receiver")
+            logger.info("Enable Receiver")
             openWAVE('test.wav')
         else:
-            logging.info("Disable Receiver")
+            logger.info("Disable Receiver")
             closeWAVE()
     CONTROL = value
 
@@ -214,21 +217,21 @@ def wrCONTROL(value):
 def wrCHANNELS(value):
     global CHANNELS
     CHANNELS = value
-    logging.info("Number of channels: {}".format(value))
+    logger.info("Number of channels: {}".format(value))
 
 ## Write SAMPLE_BITS register (user register)
 #  @param value value to write (32-bit)
 def wrSAMPLE_BITS(value):
     global SAMPLE_BITS
     SAMPLE_BITS = value
-    logging.info("Sample bits: {}".format(value))
+    logger.info("Sample bits: {}".format(value))
 
 ## Write SAMPLE_RATE register (user register)
 #  @param value value to write (32-bit)
 def wrSAMPLE_RATE(value):
     global SAMPLE_RATE
     SAMPLE_RATE = value
-    logging.info("Sample rate: {}".format(value))
+    logger.info("Sample rate: {}".format(value))
 
 
 ## Read user registers (the VSI User Registers)
@@ -236,10 +239,10 @@ def wrSAMPLE_RATE(value):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -250,7 +253,7 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     if   index == 0:
         wrCONTROL(value)
@@ -262,7 +265,7 @@ def wrRegs(index, value):
         wrSAMPLE_RATE(value)
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vio.py
+++ b/interface/python/arm_vio.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VIO:  [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # VIO Signals
@@ -34,7 +37,7 @@ Values = [0] * 64
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read Signal
@@ -42,10 +45,10 @@ def init():
 #  @return signal signal value read
 def rdSignal(mask):
     global SignalIn
-    logging.info("Python function rdSignal() called")
+    logger.info("Python function rdSignal() called")
 
     signal = SignalIn & mask
-    logging.debug("Read signal: {}, mask: {}".format(signal, mask))
+    logger.debug("Read signal: {}, mask: {}".format(signal, mask))
 
     return signal
 
@@ -56,11 +59,11 @@ def rdSignal(mask):
 #  @return None
 def wrSignal(mask, signal):
     global SignalOut
-    logging.info("Python function wrSignal() called")
+    logger.info("Python function wrSignal() called")
 
     SignalOut &= ~mask
     SignalOut |=  mask & signal
-    logging.debug("Write signal: {}, mask: {}".format(signal, mask))
+    logger.debug("Write signal: {}, mask: {}".format(signal, mask))
 
     return
 
@@ -70,10 +73,10 @@ def wrSignal(mask, signal):
 #  @return value value read (32-bit)
 def rdValue(index):
     global Values
-    logging.info("Python function rdValue() called")
+    logger.info("Python function rdValue() called")
 
     value = Values[index]
-    logging.debug("Read value at index {}: {}".format(index, value))
+    logger.debug("Read value at index {}: {}".format(index, value))
 
     return value
 
@@ -84,10 +87,10 @@ def rdValue(index):
 #  @return None
 def wrValue(index, value):
     global Values
-    logging.info("Python function wrValue() called")
+    logger.info("Python function wrValue() called")
 
     Values[index] = value
-    logging.debug("Write value at index {}: {}".format(index, value))
+    logger.debug("Write value at index {}: {}".format(index, value))
 
     return
 

--- a/interface/python/arm_vsi0.py
+++ b/interface/python/arm_vsi0.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI0: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi1.py
+++ b/interface/python/arm_vsi1.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI1: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi2.py
+++ b/interface/python/arm_vsi2.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI2: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi3.py
+++ b/interface/python/arm_vsi3.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI3: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi4.py
+++ b/interface/python/arm_vsi4.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI4: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi5.py
+++ b/interface/python/arm_vsi5.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI5: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi6.py
+++ b/interface/python/arm_vsi6.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI6: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/python/arm_vsi7.py
+++ b/interface/python/arm_vsi7.py
@@ -12,15 +12,18 @@
 
 import logging
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI7: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -55,17 +58,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -75,10 +78,10 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -89,14 +92,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -104,7 +107,7 @@ def wrTimer(index, value):
 ## Timer event (called at Timer Overflow)
 #  @return None
 def timerEvent():
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -113,11 +116,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -127,12 +130,12 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -143,10 +146,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -156,10 +159,10 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -170,10 +173,10 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/sensor/python/arm_vsi2.py
+++ b/interface/sensor/python/arm_vsi2.py
@@ -37,8 +37,8 @@ verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)logger.info("Verbosity level is set to " + level[verbosity])
-
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity
+logger.info("Verbosity level is set to " + level[verbosity])
 
 # IRQ registers
 IRQ_Status = 0

--- a/interface/sensor/python/arm_vsi2.py
+++ b/interface/sensor/python/arm_vsi2.py
@@ -28,6 +28,7 @@ import logging
 import vsi_sensor
 
 logger = logging.getLogger(__name__)
+vsi_sensor.logger = logger
 
 ## Set verbosity level
 #verbosity = logging.DEBUG

--- a/interface/sensor/python/arm_vsi2.py
+++ b/interface/sensor/python/arm_vsi2.py
@@ -37,7 +37,7 @@ verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
 logger.info("Verbosity level is set to " + level[verbosity])
 
 # IRQ registers

--- a/interface/sensor/python/arm_vsi2.py
+++ b/interface/sensor/python/arm_vsi2.py
@@ -27,15 +27,17 @@
 import logging
 import vsi_sensor
 
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI2: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # IRQ registers
@@ -70,17 +72,17 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
+    logger.info("Python function init() called")
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -90,11 +92,11 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
     value = vsi_sensor.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -105,15 +107,15 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         value = vsi_sensor.wrTimerInterval(value)
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -123,7 +125,7 @@ def wrTimer(index, value):
 def timerEvent():
     global IRQ_Status
 
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
     IRQ_Status = vsi_sensor.timerEvent(IRQ_Status)
 
@@ -134,11 +136,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -148,14 +150,14 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
     Data = vsi_sensor.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -166,10 +168,10 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
     return
 
@@ -179,13 +181,13 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
     if index <= vsi_sensor.REG_IDX_MAX:
         Regs[index] = vsi_sensor.rdRegs(index)
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -196,13 +198,13 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
     if index <= vsi_sensor.REG_IDX_MAX:
         value = vsi_sensor.wrRegs(index, value)
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/video/python/arm_vsi4.py
+++ b/interface/video/python/arm_vsi4.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2021-2024 Arm Limited. All rights reserved.
 
 # Virtual Streaming Interface instance 4 Python script
 
@@ -11,21 +11,23 @@
 #More details.
 
 import logging
-import vsi_video
+import vsi_video as vsi_video4
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI4: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6000)
-server_authkey = 'vsi_video'
+server_authkey = 'vsi_video4'
 
 
 # IRQ registers
@@ -60,18 +62,18 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
-    vsi_video.init(server_address, server_authkey)
+    logger.info("Python function init() called")
+    vsi_video4.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -81,11 +83,11 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
-    value = vsi_video.wrIRQ(IRQ_Status, value)
+    value = vsi_video4.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -96,14 +98,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -113,9 +115,9 @@ def wrTimer(index, value):
 def timerEvent():
     global IRQ_Status
 
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video4.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -124,11 +126,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -138,14 +140,14 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video.rdDataDMA(size)
+    Data = vsi_video4.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -156,12 +158,12 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video.wrDataDMA(data, size)
+    vsi_video4.wrDataDMA(data, size)
 
     return
 
@@ -171,13 +173,13 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        Regs[index] = vsi_video.rdRegs(index)
+    if index <= vsi_video4.REG_IDX_MAX:
+        Regs[index] = vsi_video4.rdRegs(index)
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -188,13 +190,13 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        value = vsi_video.wrRegs(index, value)
+    if index <= vsi_video4.REG_IDX_MAX:
+        value = vsi_video4.wrRegs(index, value)
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/video/python/arm_vsi4.py
+++ b/interface/video/python/arm_vsi4.py
@@ -11,12 +11,14 @@
 #More details.
 
 import logging
-import vsi_video as vsi_video4
+import vsi_video
+
 logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
 #verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
@@ -27,7 +29,7 @@ logger.info("Verbosity level is set to " + level[verbosity])
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6000)
-server_authkey = 'vsi_video4'
+server_authkey = 'vsi_video'
 
 
 # IRQ registers
@@ -63,7 +65,7 @@ Data = bytearray()
 #  @return None
 def init():
     logger.info("Python function init() called")
-    vsi_video4.init(server_address, server_authkey)
+    vsi_video.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
@@ -85,7 +87,7 @@ def wrIRQ(value):
     global IRQ_Status
     logger.info("Python function wrIRQ() called")
 
-    value = vsi_video4.wrIRQ(IRQ_Status, value)
+    value = vsi_video.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
     logger.debug("Write interrupt request: {}".format(value))
 
@@ -117,7 +119,7 @@ def timerEvent():
 
     logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video4.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -142,7 +144,7 @@ def rdDataDMA(size):
     global Data
     logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video4.rdDataDMA(size)
+    Data = vsi_video.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
@@ -163,7 +165,7 @@ def wrDataDMA(data, size):
     Data = data
     logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video4.wrDataDMA(data, size)
+    vsi_video.wrDataDMA(data, size)
 
     return
 
@@ -175,8 +177,8 @@ def rdRegs(index):
     global Regs
     logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video4.REG_IDX_MAX:
-        Regs[index] = vsi_video4.rdRegs(index)
+    if index <= vsi_video.REG_IDX_MAX:
+        Regs[index] = vsi_video.rdRegs(index)
 
     value = Regs[index]
     logger.debug("Read user register at index {}: {}".format(index, value))
@@ -192,8 +194,8 @@ def wrRegs(index, value):
     global Regs
     logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video4.REG_IDX_MAX:
-        value = vsi_video4.wrRegs(index, value)
+    if index <= vsi_video.REG_IDX_MAX:
+        value = vsi_video.wrRegs(index, value)
 
     Regs[index] = value
     logger.debug("Write user register at index {}: {}".format(index, value))

--- a/interface/video/python/arm_vsi4.py
+++ b/interface/video/python/arm_vsi4.py
@@ -14,6 +14,7 @@ import logging
 import vsi_video
 
 logger = logging.getLogger(__name__)
+vsi_video.logger = logger
 
 ## Set verbosity level
 #verbosity = logging.DEBUG

--- a/interface/video/python/arm_vsi5.py
+++ b/interface/video/python/arm_vsi5.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2021-2024 Arm Limited. All rights reserved.
 
 # Virtual Streaming Interface instance 5 Python script
 
@@ -11,21 +11,23 @@
 #More details.
 
 import logging
-import vsi_video
+import vsi_video as vsi_video5
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI5: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6001)
-server_authkey = 'vsi_video'
+server_authkey = 'vsi_video5'
 
 
 # IRQ registers
@@ -60,18 +62,18 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
-    vsi_video.init(server_address, server_authkey)
+    logger.info("Python function init() called")
+    vsi_video5.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -81,11 +83,11 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
-    value = vsi_video.wrIRQ(IRQ_Status, value)
+    value = vsi_video5.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -96,14 +98,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -113,9 +115,9 @@ def wrTimer(index, value):
 def timerEvent():
     global IRQ_Status
 
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video5.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -124,11 +126,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -138,14 +140,14 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video.rdDataDMA(size)
+    Data = vsi_video5.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -156,12 +158,12 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video.wrDataDMA(data, size)
+    vsi_video5.wrDataDMA(data, size)
 
     return
 
@@ -171,13 +173,13 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        Regs[index] = vsi_video.rdRegs(index)
+    if index <= vsi_video5.REG_IDX_MAX:
+        Regs[index] = vsi_video5.rdRegs(index)
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -188,13 +190,13 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        value = vsi_video.wrRegs(index, value)
+    if index <= vsi_video5.REG_IDX_MAX:
+        value = vsi_video5.wrRegs(index, value)
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/video/python/arm_vsi5.py
+++ b/interface/video/python/arm_vsi5.py
@@ -14,6 +14,7 @@ import logging
 import vsi_video
 
 logger = logging.getLogger(__name__)
+vsi_video.logger = logger
 
 ## Set verbosity level
 #verbosity = logging.DEBUG

--- a/interface/video/python/arm_vsi5.py
+++ b/interface/video/python/arm_vsi5.py
@@ -11,12 +11,14 @@
 #More details.
 
 import logging
-import vsi_video as vsi_video5
+import vsi_video
+
 logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
 #verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
@@ -27,7 +29,7 @@ logger.info("Verbosity level is set to " + level[verbosity])
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6001)
-server_authkey = 'vsi_video5'
+server_authkey = 'vsi_video'
 
 
 # IRQ registers
@@ -63,7 +65,7 @@ Data = bytearray()
 #  @return None
 def init():
     logger.info("Python function init() called")
-    vsi_video5.init(server_address, server_authkey)
+    vsi_video.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
@@ -85,7 +87,7 @@ def wrIRQ(value):
     global IRQ_Status
     logger.info("Python function wrIRQ() called")
 
-    value = vsi_video5.wrIRQ(IRQ_Status, value)
+    value = vsi_video.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
     logger.debug("Write interrupt request: {}".format(value))
 
@@ -117,7 +119,7 @@ def timerEvent():
 
     logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video5.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -142,7 +144,7 @@ def rdDataDMA(size):
     global Data
     logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video5.rdDataDMA(size)
+    Data = vsi_video.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
@@ -163,7 +165,7 @@ def wrDataDMA(data, size):
     Data = data
     logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video5.wrDataDMA(data, size)
+    vsi_video.wrDataDMA(data, size)
 
     return
 
@@ -175,8 +177,8 @@ def rdRegs(index):
     global Regs
     logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video5.REG_IDX_MAX:
-        Regs[index] = vsi_video5.rdRegs(index)
+    if index <= vsi_video.REG_IDX_MAX:
+        Regs[index] = vsi_video.rdRegs(index)
 
     value = Regs[index]
     logger.debug("Read user register at index {}: {}".format(index, value))
@@ -192,8 +194,8 @@ def wrRegs(index, value):
     global Regs
     logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video5.REG_IDX_MAX:
-        value = vsi_video5.wrRegs(index, value)
+    if index <= vsi_video.REG_IDX_MAX:
+        value = vsi_video.wrRegs(index, value)
 
     Regs[index] = value
     logger.debug("Write user register at index {}: {}".format(index, value))

--- a/interface/video/python/arm_vsi6.py
+++ b/interface/video/python/arm_vsi6.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2021-2024 Arm Limited. All rights reserved.
 
 # Virtual Streaming Interface instance 6 Python script
 
@@ -11,21 +11,23 @@
 #More details.
 
 import logging
-import vsi_video
+import vsi_video as vsi_video6
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI6: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6002)
-server_authkey = 'vsi_video'
+server_authkey = 'vsi_video6'
 
 
 # IRQ registers
@@ -60,18 +62,18 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
-    vsi_video.init(server_address, server_authkey)
+    logger.info("Python function init() called")
+    vsi_video6.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -81,11 +83,11 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
-    value = vsi_video.wrIRQ(IRQ_Status, value)
+    value = vsi_video6.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -96,14 +98,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -113,9 +115,9 @@ def wrTimer(index, value):
 def timerEvent():
     global IRQ_Status
 
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video6.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -124,11 +126,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -138,14 +140,14 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video.rdDataDMA(size)
+    Data = vsi_video6.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -156,12 +158,12 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video.wrDataDMA(data, size)
+    vsi_video6.wrDataDMA(data, size)
 
     return
 
@@ -171,13 +173,13 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        Regs[index] = vsi_video.rdRegs(index)
+    if index <= vsi_video6.REG_IDX_MAX:
+        Regs[index] = vsi_video6.rdRegs(index)
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -188,13 +190,13 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        value = vsi_video.wrRegs(index, value)
+    if index <= vsi_video6.REG_IDX_MAX:
+        value = vsi_video6.wrRegs(index, value)
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/video/python/arm_vsi6.py
+++ b/interface/video/python/arm_vsi6.py
@@ -11,12 +11,14 @@
 #More details.
 
 import logging
-import vsi_video as vsi_video6
+import vsi_video
+
 logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
 #verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
@@ -27,7 +29,7 @@ logger.info("Verbosity level is set to " + level[verbosity])
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6002)
-server_authkey = 'vsi_video6'
+server_authkey = 'vsi_video'
 
 
 # IRQ registers
@@ -63,7 +65,7 @@ Data = bytearray()
 #  @return None
 def init():
     logger.info("Python function init() called")
-    vsi_video6.init(server_address, server_authkey)
+    vsi_video.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
@@ -85,7 +87,7 @@ def wrIRQ(value):
     global IRQ_Status
     logger.info("Python function wrIRQ() called")
 
-    value = vsi_video6.wrIRQ(IRQ_Status, value)
+    value = vsi_video.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
     logger.debug("Write interrupt request: {}".format(value))
 
@@ -117,7 +119,7 @@ def timerEvent():
 
     logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video6.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -142,7 +144,7 @@ def rdDataDMA(size):
     global Data
     logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video6.rdDataDMA(size)
+    Data = vsi_video.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
@@ -163,7 +165,7 @@ def wrDataDMA(data, size):
     Data = data
     logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video6.wrDataDMA(data, size)
+    vsi_video.wrDataDMA(data, size)
 
     return
 
@@ -175,8 +177,8 @@ def rdRegs(index):
     global Regs
     logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video6.REG_IDX_MAX:
-        Regs[index] = vsi_video6.rdRegs(index)
+    if index <= vsi_video.REG_IDX_MAX:
+        Regs[index] = vsi_video.rdRegs(index)
 
     value = Regs[index]
     logger.debug("Read user register at index {}: {}".format(index, value))
@@ -192,8 +194,8 @@ def wrRegs(index, value):
     global Regs
     logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video6.REG_IDX_MAX:
-        value = vsi_video6.wrRegs(index, value)
+    if index <= vsi_video.REG_IDX_MAX:
+        value = vsi_video.wrRegs(index, value)
 
     Regs[index] = value
     logger.debug("Write user register at index {}: {}".format(index, value))

--- a/interface/video/python/arm_vsi6.py
+++ b/interface/video/python/arm_vsi6.py
@@ -14,6 +14,7 @@ import logging
 import vsi_video
 
 logger = logging.getLogger(__name__)
+vsi_video.logger = logger
 
 ## Set verbosity level
 #verbosity = logging.DEBUG

--- a/interface/video/python/arm_vsi7.py
+++ b/interface/video/python/arm_vsi7.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2023 Arm Limited. All rights reserved.
+# Copyright (c) 2021-2024 Arm Limited. All rights reserved.
 
 # Virtual Streaming Interface instance 7 Python script
 
@@ -11,21 +11,23 @@
 #More details.
 
 import logging
-import vsi_video
+import vsi_video as vsi_video7
+logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
+#verbosity = logging.INFO
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
-logging.basicConfig(format='Py: VSI7: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logging.basicConfig(format='Py: %(name)s : [%(levelname)s]\t%(message)s', level = verbosity)
+logger.info("Verbosity level is set to " + level[verbosity])
 
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6003)
-server_authkey = 'vsi_video'
+server_authkey = 'vsi_video7'
 
 
 # IRQ registers
@@ -60,18 +62,18 @@ Data = bytearray()
 ## Initialize
 #  @return None
 def init():
-    logging.info("Python function init() called")
-    vsi_video.init(server_address, server_authkey)
+    logger.info("Python function init() called")
+    vsi_video7.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
 #  @return value value read (32-bit)
 def rdIRQ():
     global IRQ_Status
-    logging.info("Python function rdIRQ() called")
+    logger.info("Python function rdIRQ() called")
 
     value = IRQ_Status
-    logging.debug("Read interrupt request: {}".format(value))
+    logger.debug("Read interrupt request: {}".format(value))
 
     return value
 
@@ -81,11 +83,11 @@ def rdIRQ():
 #  @return value value written (32-bit)
 def wrIRQ(value):
     global IRQ_Status
-    logging.info("Python function wrIRQ() called")
+    logger.info("Python function wrIRQ() called")
 
-    value = vsi_video.wrIRQ(IRQ_Status, value)
+    value = vsi_video7.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
-    logging.debug("Write interrupt request: {}".format(value))
+    logger.debug("Write interrupt request: {}".format(value))
 
     return value
 
@@ -96,14 +98,14 @@ def wrIRQ(value):
 #  @return value value written (32-bit)
 def wrTimer(index, value):
     global Timer_Control, Timer_Interval
-    logging.info("Python function wrTimer() called")
+    logger.info("Python function wrTimer() called")
 
     if   index == 0:
         Timer_Control = value
-        logging.debug("Write Timer_Control: {}".format(value))
+        logger.debug("Write Timer_Control: {}".format(value))
     elif index == 1:
         Timer_Interval = value
-        logging.debug("Write Timer_Interval: {}".format(value))
+        logger.debug("Write Timer_Interval: {}".format(value))
 
     return value
 
@@ -113,9 +115,9 @@ def wrTimer(index, value):
 def timerEvent():
     global IRQ_Status
 
-    logging.info("Python function timerEvent() called")
+    logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video7.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -124,11 +126,11 @@ def timerEvent():
 #  @return value value written (32-bit)
 def wrDMA(index, value):
     global DMA_Control
-    logging.info("Python function wrDMA() called")
+    logger.info("Python function wrDMA() called")
 
     if   index == 0:
         DMA_Control = value
-        logging.debug("Write DMA_Control: {}".format(value))
+        logger.debug("Write DMA_Control: {}".format(value))
 
     return value
 
@@ -138,14 +140,14 @@ def wrDMA(index, value):
 #  @return data data read (bytearray)
 def rdDataDMA(size):
     global Data
-    logging.info("Python function rdDataDMA() called")
+    logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video.rdDataDMA(size)
+    Data = vsi_video7.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
     data[0:n] = Data[0:n]
-    logging.debug("Read data ({} bytes)".format(size))
+    logger.debug("Read data ({} bytes)".format(size))
 
     return data
 
@@ -156,12 +158,12 @@ def rdDataDMA(size):
 #  @return None
 def wrDataDMA(data, size):
     global Data
-    logging.info("Python function wrDataDMA() called")
+    logger.info("Python function wrDataDMA() called")
 
     Data = data
-    logging.debug("Write data ({} bytes)".format(size))
+    logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video.wrDataDMA(data, size)
+    vsi_video7.wrDataDMA(data, size)
 
     return
 
@@ -171,13 +173,13 @@ def wrDataDMA(data, size):
 #  @return value value read (32-bit)
 def rdRegs(index):
     global Regs
-    logging.info("Python function rdRegs() called")
+    logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        Regs[index] = vsi_video.rdRegs(index)
+    if index <= vsi_video7.REG_IDX_MAX:
+        Regs[index] = vsi_video7.rdRegs(index)
 
     value = Regs[index]
-    logging.debug("Read user register at index {}: {}".format(index, value))
+    logger.debug("Read user register at index {}: {}".format(index, value))
 
     return value
 
@@ -188,13 +190,13 @@ def rdRegs(index):
 #  @return value value written (32-bit)
 def wrRegs(index, value):
     global Regs
-    logging.info("Python function wrRegs() called")
+    logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video.REG_IDX_MAX:
-        value = vsi_video.wrRegs(index, value)
+    if index <= vsi_video7.REG_IDX_MAX:
+        value = vsi_video7.wrRegs(index, value)
 
     Regs[index] = value
-    logging.debug("Write user register at index {}: {}".format(index, value))
+    logger.debug("Write user register at index {}: {}".format(index, value))
 
     return value
 

--- a/interface/video/python/arm_vsi7.py
+++ b/interface/video/python/arm_vsi7.py
@@ -11,12 +11,14 @@
 #More details.
 
 import logging
-import vsi_video as vsi_video7
+import vsi_video
+
 logger = logging.getLogger(__name__)
 
 ## Set verbosity level
 #verbosity = logging.DEBUG
 #verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
@@ -27,7 +29,7 @@ logger.info("Verbosity level is set to " + level[verbosity])
 
 # Video Server configuration
 server_address = ('127.0.0.1', 6003)
-server_authkey = 'vsi_video7'
+server_authkey = 'vsi_video'
 
 
 # IRQ registers
@@ -63,7 +65,7 @@ Data = bytearray()
 #  @return None
 def init():
     logger.info("Python function init() called")
-    vsi_video7.init(server_address, server_authkey)
+    vsi_video.init(server_address, server_authkey)
 
 
 ## Read interrupt request (the VSI IRQ Status Register)
@@ -85,7 +87,7 @@ def wrIRQ(value):
     global IRQ_Status
     logger.info("Python function wrIRQ() called")
 
-    value = vsi_video7.wrIRQ(IRQ_Status, value)
+    value = vsi_video.wrIRQ(IRQ_Status, value)
     IRQ_Status = value
     logger.debug("Write interrupt request: {}".format(value))
 
@@ -117,7 +119,7 @@ def timerEvent():
 
     logger.info("Python function timerEvent() called")
 
-    IRQ_Status = vsi_video7.timerEvent(IRQ_Status)
+    IRQ_Status = vsi_video.timerEvent(IRQ_Status)
 
 
 ## Write DMA registers (the VSI DMA Registers)
@@ -142,7 +144,7 @@ def rdDataDMA(size):
     global Data
     logger.info("Python function rdDataDMA() called")
 
-    Data = vsi_video7.rdDataDMA(size)
+    Data = vsi_video.rdDataDMA(size)
 
     n = min(len(Data), size)
     data = bytearray(size)
@@ -163,7 +165,7 @@ def wrDataDMA(data, size):
     Data = data
     logger.debug("Write data ({} bytes)".format(size))
 
-    vsi_video7.wrDataDMA(data, size)
+    vsi_video.wrDataDMA(data, size)
 
     return
 
@@ -175,8 +177,8 @@ def rdRegs(index):
     global Regs
     logger.info("Python function rdRegs() called")
 
-    if index <= vsi_video7.REG_IDX_MAX:
-        Regs[index] = vsi_video7.rdRegs(index)
+    if index <= vsi_video.REG_IDX_MAX:
+        Regs[index] = vsi_video.rdRegs(index)
 
     value = Regs[index]
     logger.debug("Read user register at index {}: {}".format(index, value))
@@ -192,8 +194,8 @@ def wrRegs(index, value):
     global Regs
     logger.info("Python function wrRegs() called")
 
-    if index <= vsi_video7.REG_IDX_MAX:
-        value = vsi_video7.wrRegs(index, value)
+    if index <= vsi_video.REG_IDX_MAX:
+        value = vsi_video.wrRegs(index, value)
 
     Regs[index] = value
     logger.debug("Write user register at index {}: {}".format(index, value))

--- a/interface/video/python/arm_vsi7.py
+++ b/interface/video/python/arm_vsi7.py
@@ -14,6 +14,7 @@ import logging
 import vsi_video
 
 logger = logging.getLogger(__name__)
+vsi_video.logger = logger
 
 ## Set verbosity level
 #verbosity = logging.DEBUG

--- a/interface/video/python/vsi_video_server.py
+++ b/interface/video/python/vsi_video_server.py
@@ -31,6 +31,7 @@ except Exception as e:
     print(f"VSI:Video:Server:Exception: {type(e).__name__}")
 
 logger = logging.getLogger(__name__)
+
 ## Set verbosity level
 #verbosity = logging.DEBUG
 #verbosity = logging.INFO

--- a/interface/video/python/vsi_video_server.py
+++ b/interface/video/python/vsi_video_server.py
@@ -30,14 +30,17 @@ except ImportError as err:
 except Exception as e:
     print(f"VSI:Video:Server:Exception: {type(e).__name__}")
 
-
+logger = logging.getLogger(__name__)
 ## Set verbosity level
+#verbosity = logging.DEBUG
+#verbosity = logging.INFO
+#verbosity = logging.WARNING
 verbosity = logging.ERROR
 
 # [debugging] Verbosity settings
 level = { 10: "DEBUG",  20: "INFO",  30: "WARNING",  40: "ERROR" }
 logging.basicConfig(format='VSI Server: [%(levelname)s]\t%(message)s', level = verbosity)
-logging.info("Verbosity level is set to " + level[verbosity])
+logger.info("Verbosity level is set to " + level[verbosity])
 
 # Default Server configuration
 default_address       = ('127.0.0.1', 6000)
@@ -104,7 +107,7 @@ class VideoServer:
             self.video = False
 
         file_path = os.path.join(base_dir, filename)
-        logging.debug(f"File path: {file_path}")
+        logger.debug(f"File path: {file_path}")
 
         if (mode & MODE_IO_Msk) == MODE_Input:
             self.mode = MODE_Input
@@ -160,7 +163,7 @@ class VideoServer:
                 if self.filename == "":
                     self.stream = cv2.VideoCapture(0)
                     if not self.stream.isOpened():
-                        logging.error("Failed to open Camera interface")
+                        logger.error("Failed to open Camera interface")
                         return
                 else:
                     self.stream = cv2.VideoCapture(self.filename)
@@ -168,7 +171,7 @@ class VideoServer:
                     video_fps = self.stream.get(cv2.CAP_PROP_FPS)
                     if video_fps > self.frame_rate:
                         self.frame_ratio = video_fps / self.frame_rate
-                        logging.debug(f"Frame ratio: {self.frame_ratio}")
+                        logger.debug(f"Frame ratio: {self.frame_ratio}")
             else:
                 if self.filename != "":
                     extension = str(self.filename).split('.')[-1].lower()
@@ -197,7 +200,7 @@ class VideoServer:
                         self.stream = cv2.VideoWriter(self.filename, fourcc, self.frame_rate, self.resolution)
 
         self.active = True
-        logging.info("Stream enabled")
+        logger.info("Stream enabled")
 
     # Disable Video Server
     def _disableStream(self):
@@ -207,7 +210,7 @@ class VideoServer:
                 self.frame_index = self.stream.get(cv2.CAP_PROP_POS_FRAMES)
             self.stream.release()
             self.stream = None
-        logging.info("Stream disabled")
+        logger.info("Stream disabled")
 
     # Resize frame to requested resolution in pixels
     def __resizeFrame(self, frame, resolution):
@@ -239,13 +242,13 @@ class VideoServer:
                 top    = (frame_h - crop_h) // 2
                 bottom = top + crop_h
                 frame  = frame[top : bottom, left : right]
-            logging.debug(f"Frame cropped from ({frame_w}, {frame_h}) to ({frame.shape[1]}, {frame.shape[0]})")
+            logger.debug(f"Frame cropped from ({frame_w}, {frame_h}) to ({frame.shape[1]}, {frame.shape[0]})")
         
-        logging.debug(f"Resize frame from ({frame.shape[1]}, {frame.shape[0]}) to ({resolution[0]}, {resolution[1]})")
+        logger.debug(f"Resize frame from ({frame.shape[1]}, {frame.shape[0]}) to ({resolution[0]}, {resolution[1]})")
         try:
             frame = cv2.resize(frame, resolution)
         except Exception as e:
-            logging.error(f"Error in resizeFrame(): {e}")
+            logger.error(f"Error in resizeFrame(): {e}")
 
         return frame
 
@@ -285,11 +288,11 @@ class VideoServer:
                 color_format = cv2.COLOR_YUV2BGR_I420
 
         if color_format != None:
-            logging.debug(f"Change color space to {color_format}")
+            logger.debug(f"Change color space to {color_format}")
             try:
                 frame = cv2.cvtColor(frame, color_format)
             except Exception as e:
-                logging.error(f"Error in changeColorSpace(): {e}")
+                logger.error(f"Error in changeColorSpace(): {e}")
 
         return frame
 
@@ -308,22 +311,22 @@ class VideoServer:
                 _, tmp_frame = self.stream.read()
                 self.frame_drop += (self.frame_ratio - 1)
                 if self.frame_drop > 1:
-                    logging.debug(f"Frames to drop: {self.frame_drop}")
+                    logger.debug(f"Frames to drop: {self.frame_drop}")
                     drop = int(self.frame_drop // 1)
                     for i in range(drop):
                         _, _ = self.stream.read()
-                    logging.debug(f"Frames dropped: {drop}")
+                    logger.debug(f"Frames dropped: {drop}")
                     self.frame_drop -= drop
-                    logging.debug(f"Frames left to drop: {self.frame_drop}")
+                    logger.debug(f"Frames left to drop: {self.frame_drop}")
             else:
                 _, tmp_frame = self.stream.read()
             if tmp_frame is None:
                 self.eos = True
-                logging.debug("End of stream.")
+                logger.debug("End of stream.")
         else:
             tmp_frame = cv2.imread(self.filename)
             self.eos  = True
-            logging.debug("End of stream.")
+            logger.debug("End of stream.")
 
         if tmp_frame is not None:
             tmp_frame = self.__resizeFrame(tmp_frame, self.resolution)
@@ -356,13 +359,13 @@ class VideoServer:
 
     # Run Video Server
     def run(self):
-        logging.info("Video server started")
+        logger.info("Video server started")
 
         try:
             conn = self.listener.accept()
-            logging.info(f'Connection accepted {self.listener.address}')
+            logger.info(f'Connection accepted {self.listener.address}')
         except Exception:
-            logging.error("Connection not accepted")
+            logger.error("Connection not accepted")
             return
 
         while True:
@@ -375,38 +378,38 @@ class VideoServer:
             payload = recv[1:] # Payload
 
             if  cmd == self.SET_FILENAME:
-                logging.info("Set filename called")
+                logger.info("Set filename called")
                 filename_valid = self._setFilename(payload[0], payload[1], payload[2])
                 conn.send(filename_valid)
 
             elif cmd == self.STREAM_CONFIGURE:
-                logging.info("Stream configure called")
+                logger.info("Stream configure called")
                 configuration_valid = self._configureStream(payload[0], payload[1], payload[2], payload[3])
                 conn.send(configuration_valid)
 
             elif cmd == self.STREAM_ENABLE:
-                logging.info("Enable stream called")
+                logger.info("Enable stream called")
                 self._enableStream(payload[0])
                 conn.send(self.active)
 
             elif cmd == self.STREAM_DISABLE:
-                logging.info("Disable stream called")
+                logger.info("Disable stream called")
                 self._disableStream()
                 conn.send(self.active)
 
             elif cmd == self.FRAME_READ:
-                logging.info("Read frame called")
+                logger.info("Read frame called")
                 frame = self._readFrame()
                 conn.send_bytes(frame)
                 conn.send(self.eos)
 
             elif cmd == self.FRAME_WRITE:
-                logging.info("Write frame called")
+                logger.info("Write frame called")
                 frame = conn.recv_bytes()
                 self._writeFrame(frame)
 
             elif cmd == self.CLOSE_SERVER:
-                logging.info("Close server connection")
+                logger.info("Close server connection")
                 self.stop()
 
     # Stop Video Server
@@ -418,7 +421,7 @@ class VideoServer:
             except Exception:
                 pass
         self.listener.close()
-        logging.info("Video server stopped")
+        logger.info("Video server stopped")
 
 
 # Validate IP address


### PR DESCRIPTION
More differentiation in logging was required in parallel execution of VSI scripts, when using them with AVH Corellium models out of python C libs.